### PR TITLE
Remove CR(ModuleSuffix)

### DIFF
--- a/FunToolbox/Algorithms.fs
+++ b/FunToolbox/Algorithms.fs
@@ -8,7 +8,6 @@ open System.Collections.Generic
 type Graph<'t> = private Graph of ('t * 't list) list
 type 't graph = Graph<'t>
 
-[<CR(ModuleSuffix)>]
 module Graph = 
 
     exception CycleFoundException
@@ -55,7 +54,6 @@ module Graph =
         |> Graph
 
 /// Simple probability selection in the form [(probability: int, value)]
-[<CR(ModuleSuffix)>]
 module Probability = 
     /// Sum all probabilities in the probability array.
     let sum table = 

--- a/FunToolbox/FileSystem.fs
+++ b/FunToolbox/FileSystem.fs
@@ -55,7 +55,6 @@ type Ext =
     override this.ToString() = 
         this |> function Ext extension -> extension
 
-[<CR(ModuleSuffix)>]
 module Path = 
 
     let parse str =
@@ -112,7 +111,6 @@ module Path =
     let fileExists (Path path) = 
         File.Exists path
     
-[<CR(ModuleSuffix)>]
 module Ext = 
 
     /// Parses an extension string, must be trimmed and may include a leading period.

--- a/FunToolbox/Prelude.fs
+++ b/FunToolbox/Prelude.fs
@@ -4,7 +4,6 @@ open System
 open System.Threading
 open System.Threading.Tasks
 
-type CRAttribute = CompilationRepresentationAttribute
 type RQAAttribute = RequireQualifiedAccessAttribute
 
 let [<Literal>] ModuleSuffix = CompilationRepresentationFlags.ModuleSuffix

--- a/FunToolbox/Prelude.fs
+++ b/FunToolbox/Prelude.fs
@@ -9,7 +9,6 @@ type RQAAttribute = RequireQualifiedAccessAttribute
 
 let [<Literal>] ModuleSuffix = CompilationRepresentationFlags.ModuleSuffix
 
-[<CR(ModuleSuffix)>]
 module Option =
     /// Return the value of the option, or elseValue when it is None.
     [<Obsolete("use Option.defaultValue")>]

--- a/FunToolbox/Time.Timestamp.fs
+++ b/FunToolbox/Time.Timestamp.fs
@@ -32,6 +32,6 @@ type Timestamp =
     static member op_GreaterThanOrEqual (Timestamp l, Timestamp r) = 
         l >= r
 
-[<RQA; CR(ModuleSuffix)>]
+[<RQA>]
 module Timestamp = 
     let now = Timestamp.Now


### PR DESCRIPTION
As of F#4.1 CR(ModuleSuffix) is (almost) no longer required, we could remove it

This PR is created as FunToolbox is used as submodule in other projects where CR(ModuleSuffix) is to be removed. Accept PR if this is what you want - Deny PR to have other projects remove CR(ModuleSuffix) only in its own repo/on top level.