### PR TITLE
Separate the actual subset from the mapping

### DIFF
--- a/FunToolbox.Tests/SubsetTests.fs
+++ b/FunToolbox.Tests/SubsetTests.fs
@@ -8,11 +8,11 @@ open FunToolbox
 let subset() =
     let nums = [0; 1; 2; 3; 4;5 ]
     let oddM2 n = if (n % 2) = 1 then Some 2 else None
-    let subset = nums |> Subset.select oddM2
+    let mapping, subset = nums |> Subset.select oddM2
     let oddM2 =
-        subset
+        (nums, subset)
         |> Subset.integrate
-             nums
+             mapping
              (fun (n, o) ->
                 match o with
                 | Some(m) -> n * m
@@ -21,14 +21,14 @@ let subset() =
     oddM2 |> shouldEqual [0; 2; 2; 6; 4; 10]
 
 [<Fact>]
-let ``empty subset``() =
+let ``Empty subset``() =
     let nums = [0; 1; 2; 3; 4; 5]
     let selector _ = None
-    let subset = nums |> Subset.select selector
+    let mapping, subset = nums |> Subset.select selector
     let nums2 =
-        subset
+        (nums, subset)
         |> Subset.integrate
-             nums
+             mapping
              (fun (n, o) ->
                 match o with
                 | Some(m) -> n * m
@@ -36,14 +36,14 @@ let ``empty subset``() =
     nums2 |> shouldEqual nums
 
 [<Fact>]
-let ``subset with all Some``() =
+let ``Subset with all Some``() =
     let nums = [0; 1; 2; 3; 4; 5]
     let selector _ = Some 2
-    let subset = nums |> Subset.select selector
+    let mapping, subset = nums |> Subset.select selector
     let m2 =
-        subset
+        (nums, subset)
         |> Subset.integrate
-             nums
+             mapping
              (fun (n, o) ->
                 match o with
                 | Some(m) -> n * m
@@ -51,39 +51,57 @@ let ``subset with all Some``() =
     m2 |> shouldEqual [0; 2; 4; 6; 8; 10]
 
 [<Fact>]
-let ``subset with different superset``() =
+let ``Integration with different superset``() =
     let nums = [0; 1; 2; 3; 4; 5]
     let oddM2 n = if (n % 2) = 1 then Some 2 else None
     
-    let subset = nums |> Subset.select oddM2
+    let mapping, subset = nums |> Subset.select oddM2
     
     let oddM2 =
-        subset
+        ([0; 2; 4; 6; 8; 10], subset)
         |> Subset.integrate
-             [0; 2; 4; 6; 8; 10]
-             (fun (n, o) ->
+            mapping  
+            ^ fun (n, o) ->
                 match o with
                 | Some(m) -> n * m
-                | None -> n) 
+                | None -> n
 
     oddM2 |> shouldEqual [0; 4; 4; 12; 8; 20]
 
 [<Fact>]
-let ``subset with a superset integration of a different length fails``() =
+let ``Integration with a superset of a different length fails``() =
 
     let nums = [0; 1; 2; 3; 4; 5]
     let oddM2 n = if (n % 2) = 1 then Some 2 else None
     
-    let subset = nums |> Subset.select oddM2
+    let mapping, subset = nums |> Subset.select oddM2
 
     Assert.Throws<exn>(fun () ->    
-        subset
+        ([0; 2; 4; 6; 8], subset)
         |> Subset.integrate
-             [0; 2; 4; 6; 8]
-             (fun (n, o) ->
+            mapping    
+            ^ fun (n, o) ->
                 match o with
                 | Some(m) -> n * m
-                | None -> n)
+                | None -> n
+        |> ignore
+    )
+
+[<Fact>]
+let ``Integration with a subset of a different length fails``() =
+    let nums = [0; 1; 2; 3; 4; 5]
+    let oddM2 n = if (n % 2) = 1 then Some 2 else None
+    
+    let mapping, subset = nums |> Subset.select oddM2
+
+    Assert.Throws<exn>(fun () ->    
+        (nums, [2; 3])
+        |> Subset.integrate
+            mapping    
+            ^ fun (n, o) ->
+                match o with
+                | Some(m) -> n * m
+                | None -> n
         |> ignore
     )
 
@@ -92,12 +110,12 @@ let ``empty superset``() =
     let nums = []
     let oddM2 n = if (n % 2) = 1 then Some 2 else None
     
-    let subset = nums |> Subset.select oddM2
+    let mapping, subset = nums |> Subset.select oddM2
 
     let r =
-        subset
+        ([], subset)
         |> Subset.integrate
-             []
+             mapping
              (fun (n, o) ->
                 match o with
                 | Some(m) -> n * m

--- a/FunToolbox/FunToolbox.fsproj
+++ b/FunToolbox/FunToolbox.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <Copyright>(c) 2023 Armin Sander</Copyright>
   </PropertyGroup>
 

--- a/FunToolbox/Subset.fs
+++ b/FunToolbox/Subset.fs
@@ -1,20 +1,18 @@
 [<RequireQualifiedAccess>]
 module FunToolbox.Subset
 
-/// A type representing a subset of a superset.
-type 'a subset = {
-    /// A subset of a superset.
-    Subset: 'a list
+/// A type representing a subset mapping in relation to a superset.
+type Mapping = {
     /// Flags that indicate which entries of the superset exists in the subset.
-    Filter: bool list
+    Mapping: bool list
 }
 
 /// Select a new subset from a superset.
 ///
 /// - `superset` The superset that has the same length as the original superset from which the subset was created from.
 /// - `selector` Chooses the subsets items for the superset's items.
-let select (selector: 'i -> 'a option) (superset: 'i list) : 'a subset =
-
+/// Returns the subset's mapping and the subset.
+let select (selector: 'i -> 'a option) (superset: 'i list) : Mapping * 'a list =
     let rec collect filter subset todo =
         match todo with
         | [] ->
@@ -27,16 +25,16 @@ let select (selector: 'i -> 'a option) (superset: 'i list) : 'a subset =
     let filter, subset =
         superset |> collect [] []
 
-    {
-        Subset = subset
-        Filter = filter
-    }        
+    { Mapping = filter }, subset
     
 /// Integrate the subset back to _a_ superset.
 ///
 /// The superset do not need to be equal to the original superset that was used to create the subset, but it's length
 /// must be the same as the original superset from which the subset got created.
-let integrate (superset: 'i list) (apply: 'i * 'a option -> 'r) (subsetIn: 'a subset): 'r list =
+///
+/// Use it this way:
+/// (superset, subset) |> Subset.integrate mapping (fun (supersetElement, subsetElement option) -> .. )  
+let integrate (mapping: Mapping) (apply: 'i * 'a option -> 'r) (superset: 'i list, subsetIn: 'a list): 'r list =
     
     let rec integrate result filter subset todo =
         match filter, subset, todo with
@@ -49,10 +47,12 @@ let integrate (superset: 'i list) (apply: 'i * 'a option -> 'r) (subsetIn: 'a su
         | [], [], [] -> result |> List.rev
         // Error cases.
         | _ ->
-            if List.length superset <> List.length subsetIn.Filter then
+            if List.length superset <> List.length mapping.Mapping then
                 failwith "Superset does not match length of original superset the subset was created from"
+            if List.length subsetIn <> (mapping.Mapping |> List.sumBy (fun f -> if f then 1 else 0)) then 
+                failwith "Subset does not match length of the original subset"
             else
                 failwith "Internal error"
 
     superset
-    |> integrate [] subsetIn.Filter subsetIn.Subset
+    |> integrate [] mapping.Mapping subsetIn


### PR DESCRIPTION
The possible usage patterns of subsets must not only support changing supersets, but also alternative subsets.

This PR separates the mapping from the subset and adjust the integrate function accordingly.

/cc @entenschnabel
